### PR TITLE
fix(package.json): move dependencies to devDependencies

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -65,3 +65,9 @@
 
 - **API Documentation**: Updated the README with basic usage examples, API documentation, and an overview of the cache's core features.
 - **TODO.md**: Updated with completed tasks and a list of potential future enhancements.
+
+## [1.0.1] - 2024-12-28
+
+### Fixed
+
+- Corrected `package.json` to classify dependencies under `devDependencies` where appropriate.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medishn/qiks",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A high-performance, feature-rich caching library in TypeScript designed for versatility and real-world applications.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -39,7 +39,7 @@
     "url": "https://github.com/medishen/qiks/issues"
   },
   "homepage": "https://github.com/medishen/qiks#readme",
-  "dependencies": {
+  "devDependencies": {
     "@types/chai": "^5.0.1",
     "@types/mocha": "^10.0.10",
     "@types/node": "^22.10.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,7 +7,7 @@ settings:
 importers:
 
   .:
-    dependencies:
+    devDependencies:
       '@types/chai':
         specifier: ^5.0.1
         version: 5.0.1


### PR DESCRIPTION
- Updated `package.json` to correctly classify `@types/chai`, `@types/mocha`, and `@types/node` under `devDependencies`.
- Ensures proper dependency categorization for cleaner package management.

docs(changelog): add release notes for v1.0.1

- Documented the fix in the changelog under the [1.0.1] section, including details about dependency classification updates.