### PR TITLE
chore: update to version 1.0.2

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -71,3 +71,31 @@
 ### Fixed
 
 - Corrected `package.json` to classify dependencies under `devDependencies` where appropriate.
+
+## [1.0.2] - 2025-01-02
+
+### Enhancements
+
+- **Cache `delete` Method Update**:  
+  The `delete` method in the `Cache` class now returns a boolean indicating whether the deletion was successful, instead of simply performing the action without feedback.
+- **Namespace Key Handling Improvements**:  
+  The `NamespaceManager.createCompoundKey` method was updated to accept generic key types, improving type flexibility for different key structures in namespaces. This change extends to other methods handling keys in `NamespaceCache`.
+
+- **Generalization of Key Types**:  
+  The `Qiks` and `NamespaceCache` classes now support generic key types (`K`) rather than being restricted to strings, enabling better flexibility and type safety in caching operations.
+
+- **Refined Cache Item Management**:  
+  `NamespaceCache` methods such as `get`, `set`, `delete`, and `has` now accept generic key types (`K`), allowing for more specific key management in the namespace context.
+
+### Fixes
+
+- **Improved Key Validation in `NamespaceCache`**:  
+  Fixed an issue where non-string keys could lead to unexpected behavior in the namespace cache system. The cache now properly handles and validates keys of any type.
+
+- **Mocha Test Suite Adjustment**:  
+  The test suite was adjusted to run integration tests instead of e2e tests by default, aligning with the intended testing approach for this version.
+
+### Miscellaneous
+
+- **Build Process Refinement**:  
+  Simplified the build script by removing unnecessary cleanup commands, optimizing the build process for better efficiency.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@medishn/qiks",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A high-performance, feature-rich caching library in TypeScript designed for versatility and real-world applications.",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
@@ -11,13 +11,12 @@
     "test": "tests"
   },
   "scripts": {
-    "test": "npm run test:unit & npm run test:e2e & npm run test:performance",
+    "test": "npm run test:unit & npm run test:integration & npm run test:performance",
     "test:unit": "mocha --require ts-node/register tests/unit/**/*.spec.ts",
     "test:integration": "mocha --require ts-node/register tests/integration/**/*.spec.ts",
-    "test:e2e": "mocha --require ts-node/register tests/e2e/*.spec.ts",
     "test:performance": "mocha --require ts-node/register tests/performance/**/*.spec.ts",
     "benchmark": "ts-node ./benchmark/performance.ts",
-    "build": "rm -r dist/* & tsc",
+    "build": "tsc",
     "chmod": "chmod +x ./scripts/release",
     "release": "npm run chmod && ./scripts/release"
   },

--- a/src/core/Cache.ts
+++ b/src/core/Cache.ts
@@ -157,11 +157,11 @@ export class Cache<K, V> {
     const now = Date.now();
     return now - (swrPolicy.lastFetched || 0) >= swrPolicy.staleThreshold;
   }
-  delete(key: K): void {
+  delete(key: K): boolean {
     validateKey(key);
 
     const entry = this.options.storage.get(key);
-    if (!entry) return;
+    if (!entry) return false;
     if (entry.onExpire) {
       const deserializedValue = this.options.serializer!.deserialize<string>(entry.value);
       entry.onExpire(key, deserializedValue);
@@ -177,6 +177,7 @@ export class Cache<K, V> {
     this.dependencyManager.clearDependencies(key);
     this.evictionPolicy.onRemove(key);
     this.event.emit('delete', key, value);
+    return true;
   }
 
   clear(): void {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,11 +3,11 @@ import { Cache } from './core/Cache';
 import { CacheConfigQiks, CacheItem } from './types/CacheTypes';
 import { NamespaceCache } from './core/managers/NamespaceManager';
 import { createStorageAdapter } from './utils';
-export class Qiks<K, V> extends Cache<string, V> {
+export class Qiks<K, V> extends Cache<K, V> {
   constructor(options: CacheConfigQiks<K> = {}) {
     const { maxSize = 100, policy = 'LRU', serializer = Serializer, storage = new Map() } = options;
 
-    const adaptedStorage = createStorageAdapter<string, CacheItem<string>>(storage);
+    const adaptedStorage = createStorageAdapter<K, CacheItem<string>>(storage);
 
     super({
       maxSize,
@@ -16,8 +16,8 @@ export class Qiks<K, V> extends Cache<string, V> {
       storage: adaptedStorage,
     });
   }
-  namespace(namespace: string): NamespaceCache<string, V> {
-    return new NamespaceCache<string, V>({
+  namespace(namespace: string): NamespaceCache<K, V> {
+    return new NamespaceCache<K, V>({
       namespace: namespace,
       parentStorage: this.options.storage,
       serializer: this.options.serializer,

--- a/src/types/CacheTypes.ts
+++ b/src/types/CacheTypes.ts
@@ -55,7 +55,7 @@ export interface CacheConfigQiks<K> extends BaseCacheConfig {
 }
 export interface NamespaceCacheConfig<K, V> extends BaseCacheConfig {
   serializer: CacheSerializer;
-  parentStorage: StorageAdapter<string, CacheItem<string>>;
+  parentStorage: StorageAdapter<K, CacheItem<string>>;
   namespace: string;
 }
 export interface GetOptions<K> {


### PR DESCRIPTION
- Enhance `delete` method in Cache class to return a boolean value indicating success.
- Refactor `NamespaceManager.createCompoundKey` to support generic key types, improving type flexibility.
- Generalize key type handling in `Qiks` and `NamespaceCache` classes to accept generic types.
- Adjust test suite to run integration tests by default.
- Simplify build process by removing unnecessary cleanup steps.