### PR TITLE
fix(serializer): enhance serialization/deserialization for complex types

### DIFF
--- a/src/core/managers/Serializer.ts
+++ b/src/core/managers/Serializer.ts
@@ -14,33 +14,86 @@ type Handlers = {
   Error: Handler<Error>;
   Promise: Handler<Promise<any>>;
   ArrayBuffer: Handler<ArrayBuffer>;
+  Object: Handler<Object>;
 };
 
 export class Serializer {
   static readonly type_internal = '__TYPE__';
   static handlers = {
+    Object: {
+      serialize: (value: object) => {
+        const serializedObject: Record<string, any> = {};
+        for (const key in value) {
+          if (value.hasOwnProperty(key)) {
+            const propertyValue = (value as any)[key];
+            serializedObject[key] = Serializer.serialize(propertyValue);
+          }
+        }
+        return {
+          [Serializer.type_internal]: 'Object',
+          value: serializedObject,
+        };
+      },
+
+      deserialize: (value: any): object => {
+        const deserializedObject: Record<string, any> = {};
+
+        for (const key in value.value) {
+          if (value.value.hasOwnProperty(key)) {
+            const serializedPropertyValue = value.value[key];
+            deserializedObject[key] = Serializer.deserialize(serializedPropertyValue);
+          }
+        }
+
+        return deserializedObject;
+      },
+    },
     Date: {
-      serialize: (value: Date) => ({ [Serializer.type_internal]: 'Date', value: value.toISOString() }),
-      deserialize: (value: any) => new Date(value),
+      serialize: (value: Date) => {
+        return { [Serializer.type_internal]: 'Date', value: value };
+      },
+      deserialize: (value: any) => new Date(value.value),
     },
     RegExp: {
-      serialize: (value: RegExp) => ({ [Serializer.type_internal]: 'RegExp', value: value.toString() }),
-      deserialize: (value: any) => new RegExp(value),
+      serialize: (value: RegExp) => ({
+        [Serializer.type_internal]: 'RegExp',
+        value: {
+          source: value.source,
+          flags: value.flags,
+        },
+      }),
+      deserialize: (value: any) => new RegExp(value.value.source, value.value.flags),
     },
     Function: {
-      serialize: (value: Function) => ({ [Serializer.type_internal]: 'Function', value: value.toString() }),
-      deserialize: (value: any) => new Function(`return ${value}`)(),
+      serialize: (value: Function) => ({ [Serializer.type_internal]: 'Function', value: value.toString(), name: value.name }),
+      deserialize: (value: any) => {
+        const func = new Function(`return ${value.value}`)();
+        Object.defineProperty(func, 'name', { value: value.name });
+        return func;
+      },
     },
     Map: {
-      serialize: (value: Map<any, any>) => ({ [Serializer.type_internal]: 'Map', value: Array.from(value.entries()) }),
-      deserialize: (value: any) => new Map(value.value),
+      serialize: (value: Map<any, any>) => ({
+        [Serializer.type_internal]: 'Map',
+        value: Array.from(value.entries()).map(([key, val]) => {
+          return [Serializer.serialize(key), Serializer.serialize(val)];
+        }),
+      }),
+      deserialize: (value: any) =>
+        new Map(
+          value.value.map(([key, val]: [key: string, val: string]) => {
+            return [Serializer.deserialize(key), Serializer.deserialize(val)];
+          }),
+        ),
     },
     Set: {
       serialize: (value: Set<any>) => ({ [Serializer.type_internal]: 'Set', value: Array.from(value) }),
       deserialize: (value: any) => new Set(value.value),
     },
     Buffer: {
-      serialize: (value: Buffer) => ({ [Serializer.type_internal]: 'Buffer', value: value.toString('base64') }),
+      serialize: (value: Buffer) => {
+        return { [Serializer.type_internal]: 'Buffer', value: value.toString('base64') };
+      },
       deserialize: (value: any) => Buffer.from(value.value, 'base64'),
     },
     Error: {
@@ -59,15 +112,32 @@ export class Serializer {
     },
     ArrayBuffer: {
       serialize: (value: ArrayBuffer) => ({ [Serializer.type_internal]: 'ArrayBuffer', value: Array.from(new Uint8Array(value)) }),
-      deserialize: (value: any) => new ArrayBuffer(value.value),
+      deserialize: (value: any) => {
+        const byteArray = new Uint8Array(value.value);
+        return byteArray.buffer;
+      },
     },
   };
   static serialize<V>(data: V): string {
     try {
+      if (data instanceof Date) {
+        return JSON.stringify(Serializer.handlers.Date.serialize(data));
+      }
+      if (data instanceof ArrayBuffer) {
+        return JSON.stringify(Serializer.handlers.ArrayBuffer.serialize(data));
+      }
+      if (data instanceof Buffer) {
+        return JSON.stringify(Serializer.handlers.Buffer.serialize(data));
+      }
+
       return JSON.stringify(data, (key, value) => {
-        if (value && typeof value === 'object' && value.constructor) {
+        if (value && (typeof value === 'object' || typeof value === 'function') && value.constructor) {
           const typeName = value.constructor.name as keyof Handlers;
           if (Serializer.handlers[typeName]) {
+            if (value.hasOwnProperty('__SERIALIZED__')) {
+              return value;
+            }
+            value['__SERIALIZED__'] = true;
             return Serializer.handlers[typeName].serialize(value);
           }
         }

--- a/tests/unit/core/Serializer.spec.ts
+++ b/tests/unit/core/Serializer.spec.ts
@@ -1,0 +1,153 @@
+import { expect } from 'chai';
+import { it, describe } from 'mocha';
+import { Serializer } from '../../../src/core/managers/Serializer';
+
+describe('Serializer', () => {
+  const serialize = Serializer.serialize;
+  const deserialize = Serializer.deserialize;
+
+  describe('Serializer - Date', () => {
+    it('should serialize and deserialize a Date object', () => {
+      const date = new Date();
+      const serialized = serialize(date);
+      const deserialized = deserialize<Date>(serialized);
+      expect(deserialized).to.be.instanceOf(Date);
+      expect(deserialized.getTime()).to.equal(date.getTime());
+    });
+  });
+
+  describe('Serializer - RegExp', () => {
+    it('should serialize and deserialize a RegExp object', () => {
+      const regex = /test/i;
+      const serialized = serialize(regex);
+
+      const deserialized = deserialize<RegExp>(serialized);
+      expect(deserialized).to.be.instanceOf(RegExp);
+      expect(deserialized.source).to.equal(regex.source);
+      expect(deserialized.flags).to.equal(regex.flags);
+    });
+  });
+
+  describe('Serializer - Function', () => {
+    it('should serialize and deserialize a Function', () => {
+      const func = function testFunc() {
+        return 'test';
+      };
+      const serialized = serialize(func);
+      const deserialized = deserialize<Function>(serialized);
+      expect(typeof deserialized).to.equal('function');
+      expect(deserialized.name).to.equal(func.name);
+      expect(deserialized()).to.equal(func());
+    });
+
+    it('should handle a function with regex inside', () => {
+      const func = function testFunc() {
+        return /regex/.test('regex');
+      };
+      const serialized = serialize(func);
+      const deserialized = deserialize<Function>(serialized);
+      expect(typeof deserialized).to.equal('function');
+      expect(deserialized.name).to.equal(func.name);
+      expect(deserialized()).to.equal(func());
+    });
+  });
+
+  describe('Serializer - Map', () => {
+    it('should serialize and deserialize a Map', () => {
+      const map = new Map<string, any>([
+        ['key1', 'value1'],
+        ['key2', 42],
+        ['key3', new Date()],
+      ]);
+      const serialized = serialize(map);
+      const deserialized = deserialize<Map<any, any>>(serialized);
+      expect(deserialized).to.be.instanceOf(Map);
+      expect(deserialized.size).to.equal(map.size);
+    });
+
+    it('should serialize a Map containing a function and a regex', () => {
+      const map = new Map<string, any>([
+        [
+          'func',
+          function testFunc() {
+            return 42;
+          },
+        ],
+        ['regex', /abc/i],
+      ]);
+      const serialized = serialize(map);
+      const deserialized = deserialize<Map<any, any>>(serialized);
+      expect(typeof deserialized.get('func')).to.equal('function');
+      expect(deserialized.get('func')()).to.equal(42);
+      expect(deserialized.get('regex')).to.be.instanceOf(RegExp);
+    });
+  });
+
+  describe('Serializer - Set', () => {
+    it('should serialize and deserialize a Set', () => {
+      const set = new Set([1, 2, 3, new Date(), /test/i]);
+      const serialized = serialize(set);
+      const deserialized = deserialize<Set<any>>(serialized);
+      expect(deserialized).to.be.instanceOf(Set);
+      expect(deserialized.size).to.equal(set.size);
+    });
+  });
+
+  describe('Serializer - Buffer', () => {
+    it('should serialize and deserialize a Buffer', () => {
+      const buffer = Buffer.from('Hello, World!');
+      const serialized = serialize(buffer);
+      const deserialized = deserialize<Buffer>(serialized);
+      expect(deserialized).to.be.instanceOf(Buffer);
+      expect(deserialized.toString()).to.equal(buffer.toString());
+    });
+  });
+
+  describe('Serializer - Error', () => {
+    it('should serialize and deserialize an Error', () => {
+      const error = new Error('Something went wrong');
+      const serialized = serialize(error);
+      const deserialized = deserialize<Error>(serialized);
+      expect(deserialized).to.be.instanceOf(Error);
+      expect(deserialized.message).to.equal(error.message);
+    });
+  });
+
+  describe('Serializer - Promise', () => {
+    it('should serialize and deserialize a resolved Promise', async () => {
+      const promise = Promise.resolve(42);
+      const serialized = serialize(promise);
+      const deserialized = deserialize<Promise<any>>(serialized);
+      expect(deserialized).to.be.instanceOf(Promise);
+    });
+  });
+
+  describe('Serializer - ArrayBuffer', () => {
+    it('should serialize and deserialize an ArrayBuffer', () => {
+      const buffer = new Uint8Array([1, 2, 3]).buffer;
+      const serialized = serialize(buffer);
+      const deserialized = deserialize<ArrayBuffer>(serialized);
+      expect(deserialized).to.be.instanceOf(ArrayBuffer);
+      expect(new Uint8Array(deserialized)).to.deep.equal(new Uint8Array(buffer));
+    });
+  });
+
+  describe('Serializer - Complex Cases', () => {
+    it('should handle nested structures', () => {
+      const map = new Map<string, any>([
+        ['set', new Set([1, 2, /abc/i])],
+        ['date', new Date()],
+      ]);
+      const nested = {
+        buffer: Buffer.from('nested'),
+        map,
+        regex: /complex/i,
+      };
+      const serialized = serialize(nested);
+      const deserialized = deserialize<typeof nested>(serialized);
+      expect(deserialized.buffer.toString()).to.equal(nested.buffer.toString());
+      expect(deserialized.map).to.be.instanceOf(Map);
+      expect(deserialized.regex).to.be.instanceOf(RegExp);
+    });
+  });
+});


### PR DESCRIPTION
- Added support for serializing/deserializing `Object` with nested properties.
- Improved `Date`, `RegExp`, `Function`, `Map`, and `Buffer` handlers for better accuracy and structure.
- Fixed `ArrayBuffer` deserialization to properly reconstruct buffers.
- Prevented duplicate serialization using `__SERIALIZED__` marker.